### PR TITLE
Add Quobyte CSI pod killer sidecar to CSI driver

### DIFF
--- a/charts/quobyte-csi/templates/csi-driver.yaml
+++ b/charts/quobyte-csi/templates/csi-driver.yaml
@@ -25,7 +25,7 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.quobyte.csiProvisionerName }}
@@ -90,7 +90,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: {{ .Values.quobyte.dev.k8sAttacher }}
+          image: {{ .Values.quobyte.dev.k8sAttacherImage }}
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -103,7 +103,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
       {{ if .Values.quobyte.enableSnapshots }} 
         - name: csi-snapshotter
-          image: {{ .Values.quobyte.dev.k8sSnapshotter }}
+          image: {{ .Values.quobyte.dev.k8sSnapshotterImage }}
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -440,6 +440,14 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  {{ if .Values.quobyte.podKiller.enable }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["list"]
+  {{ end }}
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs:     ['use']
@@ -461,87 +469,87 @@ roleRef:
   name: quobyte-csi-driver-registrar-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   apiGroup: rbac.authorization.k8s.io
 
-  {{ if .Values.quobyte.enableSnapshots }}
-  ---
-  kind: ClusterRole
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    # rename if there are conflicts
-    name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  rules:
-    - apiGroups: [""]
-      resources: ["events"]
-      verbs: ["list", "watch", "create", "update", "patch"]
-    # Secret permission is optional.
-    # Enable it if your driver needs secret.
-    # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
-    # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
-    - apiGroups: [""]
-      resources: ["secrets"]
-      verbs: ["get", "list"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotclasses"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotcontents"]
-      verbs: ["create", "get", "list", "watch", "update", "delete"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotcontents/status"]
-      verbs: ["update"]
-    - apiGroups: ['policy']
-      resources: ['podsecuritypolicies']
-      verbs:     ['use']
-      resourceNames:
-        - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  
-  ---
-  kind: ClusterRoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: csi-snapshotter-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  subjects:
-    - kind: ServiceAccount
-      name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-      namespace: kube-system
-  roleRef:
-    kind: ClusterRole
-    name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-    apiGroup: rbac.authorization.k8s.io
-  
-  ---
-  kind: Role
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    namespace: kube-system
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{ if .Values.quobyte.enableSnapshots }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # rename if there are conflicts
+  name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
       - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  
-  ---
-  kind: RoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+subjects:
+  - kind: ServiceAccount
+    name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     namespace: kube-system
-  subjects:
-    - kind: ServiceAccount
-      name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-      namespace: kube-system
-  roleRef:
-    kind: Role
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-    apiGroup: rbac.authorization.k8s.io
-  {{ end }}
+roleRef:
+  kind: ClusterRole
+  name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+    - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
 
 {{ else }} # Without pod security policies
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.quobyte.csiProvisionerName }}
@@ -610,7 +618,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: {{ .Values.quobyte.dev.k8sAttacher }}
+          image: {{ .Values.quobyte.dev.k8sAttacherImage }}
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -623,7 +631,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
       {{ if .Values.quobyte.enableSnapshots }}        
         - name: csi-snapshotter
-          image: {{ .Values.quobyte.dev.k8sSnapshotter }}
+          image: {{ .Values.quobyte.dev.k8sSnapshotterImage }}
           imagePullPolicy: Always
           args:
             - "--v=3"
@@ -669,6 +677,30 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
             - name: log-dir
               mountPath: /tmp
+       {{ if .Values.quobyte.podKiller.enable }}
+        - name: quobyte-pod-killer
+          securityContext:
+            privileged: true
+          image: {{ .Values.quobyte.dev.podKillerImage }}
+          imagePullPolicy: "Always"
+          args :
+            - "--node_name=$(KUBE_NODE_NAME)"
+            - "--driver_name={{ .Values.quobyte.csiProvisionerName }}"
+            - "--monitoring_interval={{ .Values.quobyte.podKiller.monitoringInterval }}"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+       {{ end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -982,6 +1014,30 @@ spec:
               mountPath: /csi
             - name: log-dir
               mountPath: /tmp
+       {{ if .Values.quobyte.podKiller.enable }}
+        - name: quobyte-pod-killer
+          securityContext:
+            privileged: true
+          image: {{ .Values.quobyte.dev.podKillerImage }}
+          imagePullPolicy: "Always"
+          args :
+            - "--node_name=$(KUBE_NODE_NAME)"
+            - "--driver_name={{ .Values.quobyte.csiProvisionerName }}"
+            - "--monitoring_interval={{ .Values.quobyte.podKiller.monitoringInterval }}"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+         {{ end }}
       volumes:
         - name: kubelet-dir
           hostPath:
@@ -1024,7 +1080,14 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
-
+  {{ if .Values.quobyte.podKiller.enable }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["list"]
+  {{ end }}
 ---
 
 kind: ClusterRoleBinding

--- a/charts/quobyte-csi/values.yaml
+++ b/charts/quobyte-csi/values.yaml
@@ -45,20 +45,28 @@ quobyte:
   # Set to true to deploy csi driver with pod security policies.
   # Change required ONLY if you have pod security policies enabled K8S environment.
   podSecurityPolicies: false
+
+  podKiller:
+    enable: true
+    # should be a valid golang time.Duration 
+    monitoringInterval: 5s
    
   # The dev configuration is intended for Quobyte Developers and internal use.
   # Please do NOT change the dev: configuration unless otherwise adviced to change.
   dev:
     # Release version
-    csiProvisionerVersion: "v1.4.0"
+    csiProvisionerVersion: "v1.4.1"
     # Release container
+    # github.com/quobyte/quobyte-csi
     csiImage: "quay.io/quobyte/csi:v1.4.0"
+    # github.com/quobyte/pod-killer
+    podKillerImage: quay.io/quobyte/pod-killer:v0.1.0
     # k8s sidecar containers (https://github.com/kubernetes-csi/)
     k8sProvisionerImage: quay.io/k8scsi/csi-provisioner:v1.6.0
     k8sClusterDriverRegistrarImage: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
     k8sResizerImage: quay.io/k8scsi/csi-resizer:v0.5.0
     k8sNodeRegistrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-    k8sAttacher: quay.io/k8scsi/csi-attacher:v2.2.0
+    k8sAttacherImage: quay.io/k8scsi/csi-attacher:v2.2.0
     # when updating image for snapshotter, update snaptshotter setup CRD
     # instructions in README
-    k8sSnapshotter: quay.io/k8scsi/csi-snapshotter:v2.1.1
+    k8sSnapshotterImage: quay.io/k8scsi/csi-snapshotter:v2.1.1


### PR DESCRIPTION
Removes application pods with stale mount points
resulted from the client restart (due to client upgrade/crash).
The responsibility of new pod creation lies with the k8s
(expectation is applications are deployed as replicasets/statefulsets/
deployments but not as plain pods).